### PR TITLE
Blazor migration 4/4: adopt improvements from the other migration attempt

### DIFF
--- a/ChannelDungeons.Web.Tests/AppTestContext.cs
+++ b/ChannelDungeons.Web.Tests/AppTestContext.cs
@@ -1,12 +1,15 @@
 using Bunit;
 using ChannelDungeons.Web.Services;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
 
 namespace ChannelDungeons.Web.Tests;
 
 /// <summary>
-/// bUnit context with the app's services registered and animation delays
-/// replaced by an instant implementation so tests run without waiting.
+/// bUnit context with the app's services registered, animation delays
+/// replaced by an instant implementation, and browser interop replaced by a
+/// no-op fake so tests run without waiting or JS.
 /// </summary>
 public abstract class AppTestContext : BunitContext
 {
@@ -16,6 +19,7 @@ public abstract class AppTestContext : BunitContext
         Services.AddSingleton<IChannelCatalog, ChannelCatalog>();
         Services.AddSingleton<IDelayProvider, InstantDelayProvider>();
         Services.AddSingleton(TimeProvider.System);
+        Services.AddSingleton<IBrowserInterop, FakeBrowserInterop>();
     }
 
     private sealed class InstantDelayProvider : IDelayProvider
@@ -24,5 +28,22 @@ public abstract class AppTestContext : BunitContext
             cancellationToken.IsCancellationRequested
                 ? Task.FromCanceled(cancellationToken)
                 : Task.CompletedTask;
+    }
+
+    /// <summary>No-op interop reporting a desktop viewport.</summary>
+    private sealed class FakeBrowserInterop : IBrowserInterop
+    {
+        public Task<bool> InitAsync<T>(DotNetObjectReference<T> reference) where T : class =>
+            Task.FromResult(false);
+
+        public Task DisposeListenersAsync() => Task.CompletedTask;
+
+        public Task ScrollToBottomAsync(ElementReference element) => Task.CompletedTask;
+
+        public Task ScrollItemIntoViewAsync(ElementReference container, int index) => Task.CompletedTask;
+
+        public Task RegisterInputKeysAsync(ElementReference input, ElementReference dropdown) => Task.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/ChannelDungeons.Web.Tests/BrowserInteropTests.cs
+++ b/ChannelDungeons.Web.Tests/BrowserInteropTests.cs
@@ -1,0 +1,85 @@
+using Bunit;
+using ChannelDungeons.Web.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace ChannelDungeons.Web.Tests;
+
+[TestClass]
+public sealed class BrowserInteropTests : BunitContext
+{
+    private BunitJSModuleInterop SetUpModule()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        return JSInterop.SetupModule("./app.js");
+    }
+
+    [TestMethod]
+    public async Task InitAsync_ReturnsViewportKindFromModule()
+    {
+        var module = SetUpModule();
+        module.Setup<bool>("init", _ => true).SetResult(true);
+        await using var interop = new BrowserInterop(JSInterop.JSRuntime);
+        using var reference = DotNetObjectReference.Create(this);
+
+        var isMobile = await interop.InitAsync(reference);
+
+        Assert.IsTrue(isMobile);
+    }
+
+    [TestMethod]
+    public async Task ScrollToBottomAsync_InvokesModuleFunction()
+    {
+        var module = SetUpModule();
+        await using var interop = new BrowserInterop(JSInterop.JSRuntime);
+
+        await interop.ScrollToBottomAsync(default);
+
+        Assert.HasCount(1, module.Invocations["scrollToBottom"]);
+    }
+
+    [TestMethod]
+    public async Task ScrollItemIntoViewAsync_PassesIndex()
+    {
+        var module = SetUpModule();
+        await using var interop = new BrowserInterop(JSInterop.JSRuntime);
+
+        await interop.ScrollItemIntoViewAsync(default, 2);
+
+        var invocation = module.Invocations["scrollItemIntoView"].Single();
+        Assert.AreEqual(2, invocation.Arguments[1]);
+    }
+
+    [TestMethod]
+    public async Task RegisterInputKeysAsync_InvokesModuleFunction()
+    {
+        var module = SetUpModule();
+        await using var interop = new BrowserInterop(JSInterop.JSRuntime);
+
+        await interop.RegisterInputKeysAsync(default, default);
+
+        Assert.HasCount(1, module.Invocations["registerInputKeys"]);
+    }
+
+    [TestMethod]
+    public async Task DisposeListenersAsync_InvokesModuleFunction()
+    {
+        var module = SetUpModule();
+        await using var interop = new BrowserInterop(JSInterop.JSRuntime);
+
+        await interop.DisposeListenersAsync();
+
+        Assert.HasCount(1, module.Invocations["dispose"]);
+    }
+
+    [TestMethod]
+    public async Task DisposeAsync_WithoutModuleUse_DoesNotImportModule()
+    {
+        var module = SetUpModule();
+        var interop = new BrowserInterop(JSInterop.JSRuntime);
+
+        await interop.DisposeAsync();
+
+        Assert.IsEmpty(module.Invocations);
+    }
+}

--- a/ChannelDungeons.Web/Components/CommandInput.razor
+++ b/ChannelDungeons.Web/Components/CommandInput.razor
@@ -1,4 +1,4 @@
-@inject IJSRuntime Js
+@inject IBrowserInterop Interop
 
 <footer>
     <div class="autocomplete-container">
@@ -58,7 +58,7 @@
             // Native keydown listener that suppresses the browser defaults for
             // navigation keys while the dropdown is open (caret moves, focus
             // loss on Tab); the Blazor handler below does the actual work.
-            await Js.InvokeVoidAsync("channelDungeons.registerInputKeys", _inputElement, _dropdownElement);
+            await Interop.RegisterInputKeysAsync(_inputElement, _dropdownElement);
         }
     }
 
@@ -81,10 +81,14 @@
     {
         if (_dropdownVisible)
         {
-            HandleDropdownKey(e.Key, out var selectedCommand);
+            HandleDropdownKey(e.Key, out var selectedCommand, out var selectionMoved);
             if (selectedCommand is not null)
             {
                 await SelectSuggestionAsync(selectedCommand);
+            }
+            else if (selectionMoved)
+            {
+                await Interop.ScrollItemIntoViewAsync(_dropdownElement, _selectedIndex);
             }
             return;
         }
@@ -95,16 +99,19 @@
         }
     }
 
-    private void HandleDropdownKey(string key, out string? selectedCommand)
+    private void HandleDropdownKey(string key, out string? selectedCommand, out bool selectionMoved)
     {
         selectedCommand = null;
+        selectionMoved = false;
         switch (key)
         {
             case "ArrowDown":
                 _selectedIndex = Math.Min(_selectedIndex + 1, _suggestions.Count - 1);
+                selectionMoved = true;
                 break;
             case "ArrowUp":
                 _selectedIndex = Math.Max(_selectedIndex - 1, 0);
+                selectionMoved = true;
                 break;
             case "Tab":
             case "Enter":

--- a/ChannelDungeons.Web/Components/CommandInput.razor
+++ b/ChannelDungeons.Web/Components/CommandInput.razor
@@ -106,12 +106,14 @@
         switch (key)
         {
             case "ArrowDown":
-                _selectedIndex = Math.Min(_selectedIndex + 1, _suggestions.Count - 1);
-                selectionMoved = true;
+                var next = Math.Min(_selectedIndex + 1, _suggestions.Count - 1);
+                selectionMoved = next != _selectedIndex;
+                _selectedIndex = next;
                 break;
             case "ArrowUp":
-                _selectedIndex = Math.Max(_selectedIndex - 1, 0);
-                selectionMoved = true;
+                var previous = Math.Max(_selectedIndex - 1, 0);
+                selectionMoved = previous != _selectedIndex;
+                _selectedIndex = previous;
                 break;
             case "Tab":
             case "Enter":

--- a/ChannelDungeons.Web/Pages/Home.razor
+++ b/ChannelDungeons.Web/Pages/Home.razor
@@ -3,7 +3,7 @@
 @inject IChannelCatalog Catalog
 @inject IDelayProvider Delays
 @inject NavigationManager Navigation
-@inject IJSRuntime Js
+@inject IBrowserInterop Interop
 @inject TimeProvider Time
 
 <PageTitle>Channel Dungeons - MMORPG in Discord</PageTitle>
@@ -81,14 +81,14 @@
         if (firstRender)
         {
             _selfReference = DotNetObjectReference.Create(this);
-            _isMobileView = await Js.InvokeAsync<bool>("channelDungeons.init", _selfReference);
+            _isMobileView = await Interop.InitAsync(_selfReference);
             await LoadInitialChannelAsync();
         }
 
         if (_scrollPending)
         {
             _scrollPending = false;
-            await Js.InvokeVoidAsync("channelDungeons.scrollToBottom", _messageArea);
+            await Interop.ScrollToBottomAsync(_messageArea);
         }
     }
 
@@ -341,7 +341,7 @@
         CancelAnimation();
         if (_selfReference is not null)
         {
-            await Js.InvokeVoidAsync("channelDungeons.dispose");
+            await Interop.DisposeListenersAsync();
             _selfReference.Dispose();
             _selfReference = null;
         }

--- a/ChannelDungeons.Web/Program.cs
+++ b/ChannelDungeons.Web/Program.cs
@@ -10,5 +10,6 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddSingleton<IChannelCatalog, ChannelCatalog>();
 builder.Services.AddSingleton<IDelayProvider, TaskDelayProvider>();
 builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddScoped<IBrowserInterop, BrowserInterop>();
 
 await builder.Build().RunAsync();

--- a/ChannelDungeons.Web/Services/BrowserInterop.cs
+++ b/ChannelDungeons.Web/Services/BrowserInterop.cs
@@ -1,0 +1,58 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace ChannelDungeons.Web.Services;
+
+/// <summary>
+/// Wrapper around the wwwroot/app.js module so components depend on typed
+/// methods instead of raw JS invocations.
+/// </summary>
+public interface IBrowserInterop : IAsyncDisposable
+{
+    /// <summary>
+    /// Registers viewport/swipe listeners calling back into the given object.
+    /// Returns whether the viewport is currently mobile-sized.
+    /// </summary>
+    Task<bool> InitAsync<T>(DotNetObjectReference<T> reference) where T : class;
+
+    /// <summary>Detaches the listeners registered by <see cref="InitAsync{T}"/>.</summary>
+    Task DisposeListenersAsync();
+
+    Task ScrollToBottomAsync(ElementReference element);
+
+    Task ScrollItemIntoViewAsync(ElementReference container, int index);
+
+    Task RegisterInputKeysAsync(ElementReference input, ElementReference dropdown);
+}
+
+public sealed class BrowserInterop(IJSRuntime jsRuntime) : IBrowserInterop
+{
+    private readonly Lazy<Task<IJSObjectReference>> _moduleTask = new(
+        () => jsRuntime.InvokeAsync<IJSObjectReference>("import", "./app.js").AsTask());
+
+    private Task<IJSObjectReference> ModuleAsync() => _moduleTask.Value;
+
+    public async Task<bool> InitAsync<T>(DotNetObjectReference<T> reference) where T : class =>
+        await (await ModuleAsync()).InvokeAsync<bool>("init", reference);
+
+    public async Task DisposeListenersAsync() =>
+        await (await ModuleAsync()).InvokeVoidAsync("dispose");
+
+    public async Task ScrollToBottomAsync(ElementReference element) =>
+        await (await ModuleAsync()).InvokeVoidAsync("scrollToBottom", element);
+
+    public async Task ScrollItemIntoViewAsync(ElementReference container, int index) =>
+        await (await ModuleAsync()).InvokeVoidAsync("scrollItemIntoView", container, index);
+
+    public async Task RegisterInputKeysAsync(ElementReference input, ElementReference dropdown) =>
+        await (await ModuleAsync()).InvokeVoidAsync("registerInputKeys", input, dropdown);
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_moduleTask.IsValueCreated)
+        {
+            var module = await _moduleTask.Value;
+            await module.DisposeAsync();
+        }
+    }
+}

--- a/ChannelDungeons.Web/wwwroot/app.js
+++ b/ChannelDungeons.Web/wwwroot/app.js
@@ -38,7 +38,7 @@ function removeListeners() {
 
 function wireErrorUiDismiss() {
   const errorUi = document.getElementById('blazor-error-ui');
-  const dismiss = errorUi && errorUi.querySelector('.dismiss');
+  const dismiss = errorUi?.querySelector('.dismiss');
   if (dismiss && !dismiss.dataset.wired) {
     dismiss.dataset.wired = 'true';
     dismiss.addEventListener('click', function () {
@@ -91,7 +91,7 @@ export function scrollToBottom(element) {
 
 /** Scrolls the container's child at the given index into view. */
 export function scrollItemIntoView(container, index) {
-  const item = container && container.children[index];
+  const item = container?.children[index];
   if (item) {
     item.scrollIntoView({ block: 'nearest' });
   }

--- a/ChannelDungeons.Web/wwwroot/app.js
+++ b/ChannelDungeons.Web/wwwroot/app.js
@@ -1,106 +1,115 @@
 /**
- * Browser interop for the Channel Dungeons Blazor app: viewport tracking,
- * swipe gestures, scrolling, and mobile height calculation.
+ * Browser interop module for the Channel Dungeons Blazor app: viewport
+ * tracking, swipe gestures, scrolling, and mobile height calculation.
+ * Loaded on demand by Services/BrowserInterop.cs.
  */
-window.channelDungeons = (function () {
-  'use strict';
 
-  const MOBILE_BREAKPOINT = 768;
-  const MIN_SWIPE_DISTANCE = 50;
+const MOBILE_BREAKPOINT = 768;
+const MIN_SWIPE_DISTANCE = 50;
 
-  let listeners = [];
+let listeners = [];
 
-  function isMobileView() {
-    return window.innerWidth <= MOBILE_BREAKPOINT;
+function isMobileView() {
+  return window.innerWidth <= MOBILE_BREAKPOINT;
+}
+
+function recalcMobileHeight() {
+  const header = document.querySelector('.channel-header');
+  const messageArea = document.querySelector('.message-area');
+  const footer = document.querySelector('footer');
+
+  if (header && messageArea && footer && isMobileView()) {
+    const reserved = header.offsetHeight + footer.offsetHeight;
+    messageArea.style.height = `calc(100% - ${reserved}px)`;
   }
+}
 
-  function recalcMobileHeight() {
-    const header = document.querySelector('.channel-header');
-    const messageArea = document.querySelector('.message-area');
-    const footer = document.querySelector('footer');
+function addListener(target, type, handler, options) {
+  target.addEventListener(type, handler, options);
+  listeners.push({ target, type, handler });
+}
 
-    if (header && messageArea && footer && isMobileView()) {
-      const reserved = header.offsetHeight + footer.offsetHeight;
-      messageArea.style.height = `calc(100% - ${reserved}px)`;
-    }
+function removeListeners() {
+  for (const { target, type, handler } of listeners) {
+    target.removeEventListener(type, handler);
   }
+  listeners = [];
+}
 
-  function addListener(target, type, handler, options) {
-    target.addEventListener(type, handler, options);
-    listeners.push({ target, type, handler });
-  }
-
-  function removeListeners() {
-    for (const { target, type, handler } of listeners) {
-      target.removeEventListener(type, handler);
-    }
-    listeners = [];
-  }
-
-  const dismissButton = document.querySelector('#blazor-error-ui .dismiss');
-  if (dismissButton) {
-    dismissButton.addEventListener('click', function () {
-      document.getElementById('blazor-error-ui').style.display = 'none';
+function wireErrorUiDismiss() {
+  const errorUi = document.getElementById('blazor-error-ui');
+  const dismiss = errorUi && errorUi.querySelector('.dismiss');
+  if (dismiss && !dismiss.dataset.wired) {
+    dismiss.dataset.wired = 'true';
+    dismiss.addEventListener('click', function () {
+      errorUi.style.display = 'none';
     });
   }
+}
 
-  return {
-    /**
-     * Registers viewport and swipe listeners that call back into .NET.
-     * Returns whether the viewport is currently mobile-sized.
-     */
-    init: function (dotNetRef) {
-      removeListeners();
+/**
+ * Registers viewport and swipe listeners that call back into .NET.
+ * Returns whether the viewport is currently mobile-sized.
+ */
+export function init(dotNetRef) {
+  removeListeners();
+  wireErrorUiDismiss();
 
-      addListener(window, 'resize', function () {
-        dotNetRef.invokeMethodAsync('OnViewportResized', isMobileView());
-        recalcMobileHeight();
-      });
+  addListener(window, 'resize', function () {
+    dotNetRef.invokeMethodAsync('OnViewportResized', isMobileView());
+    recalcMobileHeight();
+  });
 
-      let touchStartX = 0;
-      addListener(document, 'touchstart', function (e) {
-        touchStartX = e.changedTouches[0].screenX;
-      }, { passive: true });
+  let touchStartX = 0;
+  addListener(document, 'touchstart', function (e) {
+    touchStartX = e.changedTouches[0].screenX;
+  }, { passive: true });
 
-      addListener(document, 'touchend', function (e) {
-        const distance = e.changedTouches[0].screenX - touchStartX;
-        if (Math.abs(distance) > MIN_SWIPE_DISTANCE) {
-          dotNetRef.invokeMethodAsync('OnSwipe', distance > 0);
-        }
-      }, { passive: true });
-
-      recalcMobileHeight();
-      return isMobileView();
-    },
-
-    /** Detaches the listeners registered by init. */
-    dispose: function () {
-      removeListeners();
-    },
-
-    scrollToBottom: function (element) {
-      if (element) {
-        setTimeout(function () {
-          element.scrollTop = element.scrollHeight;
-        }, 10);
-      }
-    },
-
-    /**
-     * Suppresses browser defaults for autocomplete navigation keys while the
-     * dropdown is open, so the caret does not move and Tab does not steal
-     * focus. The Blazor keydown handler performs the actual navigation.
-     */
-    registerInputKeys: function (input, dropdown) {
-      if (!input || !dropdown) {
-        return;
-      }
-      input.addEventListener('keydown', function (e) {
-        const handledKeys = ['ArrowDown', 'ArrowUp', 'Tab', 'Enter'];
-        if (dropdown.classList.contains('visible') && handledKeys.includes(e.key)) {
-          e.preventDefault();
-        }
-      });
+  addListener(document, 'touchend', function (e) {
+    const distance = e.changedTouches[0].screenX - touchStartX;
+    if (Math.abs(distance) > MIN_SWIPE_DISTANCE) {
+      dotNetRef.invokeMethodAsync('OnSwipe', distance > 0);
     }
-  };
-})();
+  }, { passive: true });
+
+  recalcMobileHeight();
+  return isMobileView();
+}
+
+/** Detaches the listeners registered by init. */
+export function dispose() {
+  removeListeners();
+}
+
+export function scrollToBottom(element) {
+  if (element) {
+    setTimeout(function () {
+      element.scrollTop = element.scrollHeight;
+    }, 10);
+  }
+}
+
+/** Scrolls the container's child at the given index into view. */
+export function scrollItemIntoView(container, index) {
+  const item = container && container.children[index];
+  if (item) {
+    item.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+/**
+ * Suppresses browser defaults for autocomplete navigation keys while the
+ * dropdown is open, so the caret does not move and Tab does not steal
+ * focus. The Blazor keydown handler performs the actual navigation.
+ */
+export function registerInputKeys(input, dropdown) {
+  if (!input || !dropdown) {
+    return;
+  }
+  input.addEventListener('keydown', function (e) {
+    const handledKeys = ['ArrowDown', 'ArrowUp', 'Tab', 'Enter'];
+    if (dropdown.classList.contains('visible') && handledKeys.includes(e.key)) {
+      e.preventDefault();
+    }
+  });
+}

--- a/ChannelDungeons.Web/wwwroot/index.html
+++ b/ChannelDungeons.Web/wwwroot/index.html
@@ -51,7 +51,6 @@
         <a href="." class="reload">Reload</a>
         <button type="button" class="dismiss" aria-label="Dismiss error">🗙</button>
     </div>
-    <script src="app.js"></script>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
 </body>
 

--- a/ChannelDungeons.Web/wwwroot/styles.css
+++ b/ChannelDungeons.Web/wwwroot/styles.css
@@ -802,6 +802,12 @@ code {
    11. Blazor Migration Additions
    ========================================================================== */
 
+/* Blazor's root mount point sits between body and .discord-app; it needs an
+   explicit height so percentage-height rules resolve against the viewport */
+#app {
+  height: 100%;
+}
+
 /* Channel entries are real links (keyboard focusable) styled like the
    original list items */
 .channel a {


### PR DESCRIPTION
Follow-up to the migration series (stacked on #28), porting the three genuinely better ideas found while comparing against the other migration attempt (`41d898d`):

1. **ES-module interop behind a typed wrapper** — `wwwroot/app.js` is now an ES module loaded on demand through `IBrowserInterop`/`BrowserInterop` instead of a `window.channelDungeons` global. Components depend on typed methods; component tests use a no-op fake, and the wrapper itself has dedicated tests via bUnit's module interop.
2. **Autocomplete `scrollIntoView`** — keyboard navigation scrolls the selected suggestion into view, restoring a detail of the original site.
3. **`#app { height: 100% }`** — Blazor mounts the app inside `#app`, which broke the original's percentage-height chain (`body` → `.discord-app`); the explicit height restores it.

57 tests passing (6 new for the interop wrapper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)